### PR TITLE
Fix shebang for capture script

### DIFF
--- a/zsh/innocam/scripts/capture01.zsh
+++ b/zsh/innocam/scripts/capture01.zsh
@@ -1,4 +1,4 @@
-#!/bin/zsh
+#!/usr/bin/env zsh
 
 # --------------------------------------------------------------
 # This script was developed with the assistance of ChatGPT-4o 


### PR DESCRIPTION
## Summary
- make the capture script portable by using `#!/usr/bin/env zsh`

## Testing
- `shellcheck zsh/innocam/scripts/capture01.zsh` *(fails: ShellCheck only supports sh/bash/dash/ksh scripts)*

------
https://chatgpt.com/codex/tasks/task_e_6849ea0741fc8326982bd9fbec15ff34