### PR TITLE
Add custom GST version support

### DIFF
--- a/zsh/innocam/README.md
+++ b/zsh/innocam/README.md
@@ -213,10 +213,16 @@ Object held freehand in front of the camera, captured via `c` during streaming:
 </table>
 
 ## References
+
+### Documentation
  
 - [Raspberry Pi Camera Software Documentation](https://www.raspberrypi.com/documentation/computers/camera_software.html)
 - [GStreamer Official Documentation](https://gstreamer.freedesktop.org/documentation/)
 - [FFmpeg Tools Documentation (ffplay)](https://ffmpeg.org/ffplay.html)
 - [Innomaker Camera](https://github.com/INNO-MAKER/cam-imx708af)
+
+### Source
+
+- [GStreamer Source](https://gitlab.freedesktop.org/gstreamer/gstreamer.git)
  
 

--- a/zsh/innocam/README.md
+++ b/zsh/innocam/README.md
@@ -47,9 +47,14 @@ Streaming was tested on the following platforms:
 
   * Default: `rpicam-vid` (UDP).
   * Optional: `gst-launch-1.0` (GStreamer) via the `--gst` option.
-* Configurable resolution (`--width`, `--height`) and framerate (`--framerate`).
+  * Use a specific GStreamer binary with the `--gstver` option.
+  * Configurable resolution (`--width`, `--height`) and framerate (`--framerate`).
 * Preview the video stream on the client using `ffplay` or GStreamer.
 * Press `c` in the script to capture a still image with `rpicam-still`, saved locally on the Pi.
+
+When streaming with GStreamer, the `--gstver` option lets you select which
+`gst-launch-1.0` binary to run. This is useful if you compiled multiple
+versions as described in [README_CompileRPiGS.md](README_CompileRPiGS.md).
 
 ## Requirements
 
@@ -73,6 +78,9 @@ Streaming was tested on the following platforms:
         gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
         gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav
     ```
+
+   Alternatively you can compile GStreamer yourself from the git repository.
+   See [README_CompileRPiGS.md](README_CompileRPiGS.md) for detailed instructions.
 
 3. Test the camera:
     ```bash
@@ -165,6 +173,12 @@ Alternatively, run it directly from the repository directory:
 cd RPiTools
 chmod +x zsh/innocam/scripts/capture01.zsh
 ./zsh/innocam/scripts/capture01.zsh
+```
+
+To use a self-compiled GStreamer version:
+
+```bash
+./zsh/innocam/scripts/capture01.zsh --gst --gstver /opt/gstreamer/1.24.3/bin/gst-launch-1.0
 ```
 
 Show the help to choose the right options and values:

--- a/zsh/innocam/README_CompileRPiGS.md
+++ b/zsh/innocam/README_CompileRPiGS.md
@@ -1,0 +1,44 @@
+# Compile and Install GStreamer on Raspberry Pi OS
+
+This guide explains how to build GStreamer from the official Git repository on Raspberry Pi OS. Each version is installed into its own directory under `/opt/gstreamer`, so multiple versions can coexist.
+
+## Prerequisites
+
+```bash
+sudo apt update
+sudo apt install --no-install-recommends git meson ninja-build build-essential \ 
+    python3-pip python3-setuptools python3-wheel bison flex ragel gettext \
+    cmake libglib2.0-dev libdrm-dev libgudev-1.0-dev libjpeg-dev \
+    liborc-0.4-dev libtheora-dev libvorbis-dev libx264-dev libwayland-dev
+```
+
+## Clone the repositories
+
+```bash
+mkdir -p ~/src && cd ~/src
+ git clone https://gitlab.freedesktop.org/gstreamer/gstreamer.git
+```
+
+## Build and install
+
+Choose a version tag (for example `1.24.3`) and set an installation prefix:
+
+```bash
+cd gstreamer
+git checkout 1.24.3
+meson setup build --prefix=/opt/gstreamer/1.24.3
+meson compile -C build
+sudo meson install -C build
+```
+
+After installation you will find the `gst-launch-1.0` binary in `/opt/gstreamer/1.24.3/bin/`.
+
+## Using the compiled version
+
+Call the script with the `--gstver` option and provide the path to the desired `gst-launch-1.0` executable, e.g.
+
+```bash
+capture --gst --gstver /opt/gstreamer/1.24.3/bin/gst-launch-1.0
+```
+
+Older versions remain in their respective directories, allowing you to keep several versions in parallel.

--- a/zsh/innocam/README_CompileRPiGS.md
+++ b/zsh/innocam/README_CompileRPiGS.md
@@ -6,7 +6,7 @@ This guide explains how to build GStreamer from the official Git repository on R
 
 ```bash
 sudo apt update
-sudo apt install --no-install-recommends git meson ninja-build build-essential \ 
+sudo apt install --no-install-recommends git meson ninja-build build-essential \
     python3-pip python3-setuptools python3-wheel bison flex ragel gettext \
     cmake libglib2.0-dev libdrm-dev libgudev-1.0-dev libjpeg-dev \
     liborc-0.4-dev libtheora-dev libvorbis-dev libx264-dev libwayland-dev
@@ -15,30 +15,30 @@ sudo apt install --no-install-recommends git meson ninja-build build-essential \
 ## Clone the repositories
 
 ```bash
-mkdir -p ~/src && cd ~/src
- git clone https://gitlab.freedesktop.org/gstreamer/gstreamer.git
+mkdir -p ~/gstreamer/src && cd ~/gstreamer/src
+git clone https://gitlab.freedesktop.org/gstreamer/gstreamer.git
 ```
 
 ## Build and install
 
-Choose a version tag (for example `1.24.3`) and set an installation prefix:
+Choose a version tag (for example `1.26.2`) and set an installation prefix:
 
 ```bash
 cd gstreamer
-git checkout 1.24.3
-meson setup build --prefix=/opt/gstreamer/1.24.3
+git checkout 1.26.2
+meson setup build --prefix=/opt/gstreamer/1.26.2
 meson compile -C build
 sudo meson install -C build
 ```
 
-After installation you will find the `gst-launch-1.0` binary in `/opt/gstreamer/1.24.3/bin/`.
+After installation you will find the `gst-launch-1.0` binary in `/opt/gstreamer/1.26.2/bin/`.
 
 ## Using the compiled version
 
 Call the script with the `--gstver` option and provide the path to the desired `gst-launch-1.0` executable, e.g.
 
 ```bash
-capture --gst --gstver /opt/gstreamer/1.24.3/bin/gst-launch-1.0
+capture --gst --gstver /opt/gstreamer/1.26.2/bin/gst-launch-1.0
 ```
 
 Older versions remain in their respective directories, allowing you to keep several versions in parallel.

--- a/zsh/innocam/scripts/capture01.zsh
+++ b/zsh/innocam/scripts/capture01.zsh
@@ -40,12 +40,13 @@ Options:
   --framerate <value>   Set video framerate (default: 30, only for rpicam-vid)
   --clientip <value>    Set client IP address (default: 127.0.0.1)
   --clientport <value>  Set client port (default: 5000)
-  --gstver <path>      Path to gst-launch executable (default: /usr/bin/gst-launch-1.0)
+  --gstver <path>       Path to gst-launch executable (default: /usr/bin/gst-launch-1.0)
   -h, --help            Show this help message and exit
 
 Note:
   - The options --width, --height, and --framerate are only effective with the rpicam-vid streamer.
   - When using GStreamer (--gst), these options are ignored.
+  - If GStreamer (--gst) is used, --gstver can be specified; otherwise, it is ignored.
 
 Example:
   $0 --rpicam --width 1280 --height 720 --framerate 25


### PR DESCRIPTION
## Summary
- add compile instructions for GStreamer on RPi
- allow choosing gst-launch binary with `--gstver`
- show gst-launch version when streaming
- document new option in README

## Testing
- `bash -n zsh/innocam/scripts/capture01.zsh`

------
https://chatgpt.com/codex/tasks/task_e_684bc29851448326beed994cc0a098d2